### PR TITLE
Optimize code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ async fn main() -> Anyhow<()> {
         let config = &config;
         async move {
             let (user, password) = {
-                let mut temp = account.split(":");
+                let mut temp = account.split(':');
                 (temp.next(), temp.next())
             };
 


### PR DESCRIPTION
The code does use a `&'static str` for a character instead of a `char`, which does not comply with the so-called `Karl Klammer Rules`. So I decided to fix this bug by replacing the double-quotes with single-quotes.